### PR TITLE
chore: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,33 @@
 version: 2
 
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/"
+      interval: 'weekly'
+    pull-request-branch-name:
+      separator: _
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+
+  - package-ecosystem: 'cargo'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    pull-request-branch-name:
+      separator: _
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    groups:
+      prod:
+        dependency-type: production
+        patterns:
+          - '*'
+      dev:
+        dependency-type: development
+        patterns:
+          - '*'

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,9 +1,9 @@
 use color_eyre::eyre::{Context, Result};
 use ratatui::{
+  Frame,
   crossterm::event::{self, Event, KeyEventKind},
   prelude::*,
   widgets::{Block, Borders, Paragraph, Widget, Wrap},
-  Frame,
 };
 
 use crate::tui::Tui;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,12 +1,12 @@
 use std::io::{self, Stdout};
 
 use ratatui::{
+  Terminal,
   crossterm::{
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
   },
   prelude::CrosstermBackend,
-  Terminal,
 };
 
 /// A type alias for the terminal type used in this application


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yml` configuration file and minor code cleanup from `make lint` command.

Dependabot configuration improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L4-R33): Added `pull-request-branch-name` and `ignore` settings for both `github-actions` and `cargo` ecosystems, and added `groups` settings for the `cargo` ecosystem to differentiate between production and development dependencies.

Code cleanup:

* [`src/app/mod.rs`](diffhunk://#diff-b2db4128ee8d3fd19ff317f148c1b2d9e8e6fe7bcd711ca80b5617c21dd5b97cR3-L6): Reordered imports to place `Frame` in alphabetical order.
* [`src/tui/mod.rs`](diffhunk://#diff-fb8aef9cea1c223a4d74ddbc7d1b7acbb04ddb3a84227e2fdde704fff3f77edbR4-L9): Reordered imports to place `Terminal` in alphabetical order and grouped related imports together.